### PR TITLE
Add per-controller Swagger docs and endpoint DTO records

### DIFF
--- a/src/main/java/de/pschiessle/lumenforge/components/category/swagger/CategoryGetAllRequestDTO.java
+++ b/src/main/java/de/pschiessle/lumenforge/components/category/swagger/CategoryGetAllRequestDTO.java
@@ -1,0 +1,7 @@
+package de.pschiessle.lumenforge.components.category.swagger;
+
+public record CategoryGetAllRequestDTO(
+        Integer page,
+        Integer size,
+        String sort
+) {}

--- a/src/main/java/de/pschiessle/lumenforge/components/category/swagger/CategoryGetAllResponseDTO.java
+++ b/src/main/java/de/pschiessle/lumenforge/components/category/swagger/CategoryGetAllResponseDTO.java
@@ -1,0 +1,11 @@
+package de.pschiessle.lumenforge.components.category.swagger;
+
+import java.util.List;
+
+public record CategoryGetAllResponseDTO(
+        List<CategoryResponseDTO> content,
+        Integer pageNumber,
+        Integer pageSize,
+        Long totalElements,
+        Integer totalPages
+) {}

--- a/src/main/java/de/pschiessle/lumenforge/components/category/swagger/CategoryResponseDTO.java
+++ b/src/main/java/de/pschiessle/lumenforge/components/category/swagger/CategoryResponseDTO.java
@@ -1,0 +1,8 @@
+package de.pschiessle.lumenforge.components.category.swagger;
+
+public record CategoryResponseDTO(
+        Long id,
+        String uuid,
+        String name,
+        String description
+) {}

--- a/src/main/java/de/pschiessle/lumenforge/components/category/swagger/CategorySearchRequestDTO.java
+++ b/src/main/java/de/pschiessle/lumenforge/components/category/swagger/CategorySearchRequestDTO.java
@@ -1,0 +1,8 @@
+package de.pschiessle.lumenforge.components.category.swagger;
+
+public record CategorySearchRequestDTO(
+        String query,
+        Integer page,
+        Integer size,
+        String sort
+) {}

--- a/src/main/java/de/pschiessle/lumenforge/components/category/swagger/CategorySearchResponseDTO.java
+++ b/src/main/java/de/pschiessle/lumenforge/components/category/swagger/CategorySearchResponseDTO.java
@@ -1,0 +1,11 @@
+package de.pschiessle.lumenforge.components.category.swagger;
+
+import java.util.List;
+
+public record CategorySearchResponseDTO(
+        List<CategoryResponseDTO> content,
+        Integer pageNumber,
+        Integer pageSize,
+        Long totalElements,
+        Integer totalPages
+) {}

--- a/src/main/java/de/pschiessle/lumenforge/components/device/swagger/DeviceCreateRequestDTO.java
+++ b/src/main/java/de/pschiessle/lumenforge/components/device/swagger/DeviceCreateRequestDTO.java
@@ -1,0 +1,7 @@
+package de.pschiessle.lumenforge.components.device.swagger;
+
+import de.pschiessle.lumenforge.components.device.DeviceRequestDTO;
+
+public record DeviceCreateRequestDTO(
+        DeviceRequestDTO device
+) {}

--- a/src/main/java/de/pschiessle/lumenforge/components/device/swagger/DeviceCreateResponseDTO.java
+++ b/src/main/java/de/pschiessle/lumenforge/components/device/swagger/DeviceCreateResponseDTO.java
@@ -1,0 +1,7 @@
+package de.pschiessle.lumenforge.components.device.swagger;
+
+import de.pschiessle.lumenforge.components.device.DeviceResponseDTO;
+
+public record DeviceCreateResponseDTO(
+        DeviceResponseDTO device
+) {}

--- a/src/main/java/de/pschiessle/lumenforge/components/device/swagger/DeviceDeleteRequestDTO.java
+++ b/src/main/java/de/pschiessle/lumenforge/components/device/swagger/DeviceDeleteRequestDTO.java
@@ -1,0 +1,5 @@
+package de.pschiessle.lumenforge.components.device.swagger;
+
+public record DeviceDeleteRequestDTO(
+        Long id
+) {}

--- a/src/main/java/de/pschiessle/lumenforge/components/device/swagger/DeviceDeleteResponseDTO.java
+++ b/src/main/java/de/pschiessle/lumenforge/components/device/swagger/DeviceDeleteResponseDTO.java
@@ -1,0 +1,5 @@
+package de.pschiessle.lumenforge.components.device.swagger;
+
+public record DeviceDeleteResponseDTO(
+        String message
+) {}

--- a/src/main/java/de/pschiessle/lumenforge/components/device/swagger/DeviceGetByIdRequestDTO.java
+++ b/src/main/java/de/pschiessle/lumenforge/components/device/swagger/DeviceGetByIdRequestDTO.java
@@ -1,0 +1,5 @@
+package de.pschiessle.lumenforge.components.device.swagger;
+
+public record DeviceGetByIdRequestDTO(
+        Long id
+) {}

--- a/src/main/java/de/pschiessle/lumenforge/components/device/swagger/DeviceGetByIdResponseDTO.java
+++ b/src/main/java/de/pschiessle/lumenforge/components/device/swagger/DeviceGetByIdResponseDTO.java
@@ -1,0 +1,7 @@
+package de.pschiessle.lumenforge.components.device.swagger;
+
+import de.pschiessle.lumenforge.components.device.DeviceResponseDTO;
+
+public record DeviceGetByIdResponseDTO(
+        DeviceResponseDTO device
+) {}

--- a/src/main/java/de/pschiessle/lumenforge/components/device/swagger/DeviceGetByUuidRequestDTO.java
+++ b/src/main/java/de/pschiessle/lumenforge/components/device/swagger/DeviceGetByUuidRequestDTO.java
@@ -1,0 +1,7 @@
+package de.pschiessle.lumenforge.components.device.swagger;
+
+import java.util.UUID;
+
+public record DeviceGetByUuidRequestDTO(
+        UUID uuid
+) {}

--- a/src/main/java/de/pschiessle/lumenforge/components/device/swagger/DeviceGetByUuidResponseDTO.java
+++ b/src/main/java/de/pschiessle/lumenforge/components/device/swagger/DeviceGetByUuidResponseDTO.java
@@ -1,0 +1,7 @@
+package de.pschiessle.lumenforge.components.device.swagger;
+
+import de.pschiessle.lumenforge.components.device.DeviceResponseDTO;
+
+public record DeviceGetByUuidResponseDTO(
+        DeviceResponseDTO device
+) {}

--- a/src/main/java/de/pschiessle/lumenforge/components/device/swagger/DeviceGetPageBasicRequestDTO.java
+++ b/src/main/java/de/pschiessle/lumenforge/components/device/swagger/DeviceGetPageBasicRequestDTO.java
@@ -1,0 +1,8 @@
+package de.pschiessle.lumenforge.components.device.swagger;
+
+public record DeviceGetPageBasicRequestDTO(
+        String q,
+        Integer page,
+        Integer size,
+        String sort
+) {}

--- a/src/main/java/de/pschiessle/lumenforge/components/device/swagger/DeviceGetPageBasicResponseDTO.java
+++ b/src/main/java/de/pschiessle/lumenforge/components/device/swagger/DeviceGetPageBasicResponseDTO.java
@@ -1,0 +1,13 @@
+package de.pschiessle.lumenforge.components.device.swagger;
+
+import de.pschiessle.lumenforge.components.device.dto.DeviceListDTO;
+
+import java.util.List;
+
+public record DeviceGetPageBasicResponseDTO(
+        List<DeviceListDTO> content,
+        Integer pageNumber,
+        Integer pageSize,
+        Long totalElements,
+        Integer totalPages
+) {}

--- a/src/main/java/de/pschiessle/lumenforge/components/device/swagger/DeviceGetPageWithStockRequestDTO.java
+++ b/src/main/java/de/pschiessle/lumenforge/components/device/swagger/DeviceGetPageWithStockRequestDTO.java
@@ -1,0 +1,8 @@
+package de.pschiessle.lumenforge.components.device.swagger;
+
+public record DeviceGetPageWithStockRequestDTO(
+        String q,
+        Integer page,
+        Integer size,
+        String sort
+) {}

--- a/src/main/java/de/pschiessle/lumenforge/components/device/swagger/DeviceGetPageWithStockResponseDTO.java
+++ b/src/main/java/de/pschiessle/lumenforge/components/device/swagger/DeviceGetPageWithStockResponseDTO.java
@@ -1,0 +1,13 @@
+package de.pschiessle.lumenforge.components.device.swagger;
+
+import de.pschiessle.lumenforge.components.device.dto.DeviceListWithStockDTO;
+
+import java.util.List;
+
+public record DeviceGetPageWithStockResponseDTO(
+        List<DeviceListWithStockDTO> content,
+        Integer pageNumber,
+        Integer pageSize,
+        Long totalElements,
+        Integer totalPages
+) {}

--- a/src/main/java/de/pschiessle/lumenforge/components/device/swagger/DeviceUpdateRequestDTO.java
+++ b/src/main/java/de/pschiessle/lumenforge/components/device/swagger/DeviceUpdateRequestDTO.java
@@ -1,0 +1,8 @@
+package de.pschiessle.lumenforge.components.device.swagger;
+
+import de.pschiessle.lumenforge.components.device.DeviceRequestDTO;
+
+public record DeviceUpdateRequestDTO(
+        Long id,
+        DeviceRequestDTO device
+) {}

--- a/src/main/java/de/pschiessle/lumenforge/components/device/swagger/DeviceUpdateResponseDTO.java
+++ b/src/main/java/de/pschiessle/lumenforge/components/device/swagger/DeviceUpdateResponseDTO.java
@@ -1,0 +1,7 @@
+package de.pschiessle.lumenforge.components.device.swagger;
+
+import de.pschiessle.lumenforge.components.device.DeviceResponseDTO;
+
+public record DeviceUpdateResponseDTO(
+        DeviceResponseDTO device
+) {}

--- a/src/main/java/de/pschiessle/lumenforge/components/maintenancestatus/swagger/MaintenanceStatusGetAllRequestDTO.java
+++ b/src/main/java/de/pschiessle/lumenforge/components/maintenancestatus/swagger/MaintenanceStatusGetAllRequestDTO.java
@@ -1,0 +1,7 @@
+package de.pschiessle.lumenforge.components.maintenancestatus.swagger;
+
+public record MaintenanceStatusGetAllRequestDTO(
+        Integer page,
+        Integer size,
+        String sort
+) {}

--- a/src/main/java/de/pschiessle/lumenforge/components/maintenancestatus/swagger/MaintenanceStatusGetAllResponseDTO.java
+++ b/src/main/java/de/pschiessle/lumenforge/components/maintenancestatus/swagger/MaintenanceStatusGetAllResponseDTO.java
@@ -1,0 +1,11 @@
+package de.pschiessle.lumenforge.components.maintenancestatus.swagger;
+
+import java.util.List;
+
+public record MaintenanceStatusGetAllResponseDTO(
+        List<MaintenanceStatusResponseDTO> content,
+        Integer pageNumber,
+        Integer pageSize,
+        Long totalElements,
+        Integer totalPages
+) {}

--- a/src/main/java/de/pschiessle/lumenforge/components/maintenancestatus/swagger/MaintenanceStatusResponseDTO.java
+++ b/src/main/java/de/pschiessle/lumenforge/components/maintenancestatus/swagger/MaintenanceStatusResponseDTO.java
@@ -1,0 +1,8 @@
+package de.pschiessle.lumenforge.components.maintenancestatus.swagger;
+
+public record MaintenanceStatusResponseDTO(
+        Long id,
+        String uuid,
+        String name,
+        String description
+) {}

--- a/src/main/java/de/pschiessle/lumenforge/components/maintenancestatus/swagger/MaintenanceStatusSearchRequestDTO.java
+++ b/src/main/java/de/pschiessle/lumenforge/components/maintenancestatus/swagger/MaintenanceStatusSearchRequestDTO.java
@@ -1,0 +1,8 @@
+package de.pschiessle.lumenforge.components.maintenancestatus.swagger;
+
+public record MaintenanceStatusSearchRequestDTO(
+        String query,
+        Integer page,
+        Integer size,
+        String sort
+) {}

--- a/src/main/java/de/pschiessle/lumenforge/components/maintenancestatus/swagger/MaintenanceStatusSearchResponseDTO.java
+++ b/src/main/java/de/pschiessle/lumenforge/components/maintenancestatus/swagger/MaintenanceStatusSearchResponseDTO.java
@@ -1,0 +1,11 @@
+package de.pschiessle.lumenforge.components.maintenancestatus.swagger;
+
+import java.util.List;
+
+public record MaintenanceStatusSearchResponseDTO(
+        List<MaintenanceStatusResponseDTO> content,
+        Integer pageNumber,
+        Integer pageSize,
+        Long totalElements,
+        Integer totalPages
+) {}

--- a/src/main/java/de/pschiessle/lumenforge/components/stock/swagger/StockDeleteByDeviceRequestDTO.java
+++ b/src/main/java/de/pschiessle/lumenforge/components/stock/swagger/StockDeleteByDeviceRequestDTO.java
@@ -1,0 +1,7 @@
+package de.pschiessle.lumenforge.components.stock.swagger;
+
+import java.util.UUID;
+
+public record StockDeleteByDeviceRequestDTO(
+        UUID deviceUuid
+) {}

--- a/src/main/java/de/pschiessle/lumenforge/components/stock/swagger/StockDeleteByDeviceResponseDTO.java
+++ b/src/main/java/de/pschiessle/lumenforge/components/stock/swagger/StockDeleteByDeviceResponseDTO.java
@@ -1,0 +1,5 @@
+package de.pschiessle.lumenforge.components.stock.swagger;
+
+public record StockDeleteByDeviceResponseDTO(
+        String message
+) {}

--- a/src/main/java/de/pschiessle/lumenforge/components/stock/swagger/StockGetByDeviceRequestDTO.java
+++ b/src/main/java/de/pschiessle/lumenforge/components/stock/swagger/StockGetByDeviceRequestDTO.java
@@ -1,0 +1,7 @@
+package de.pschiessle.lumenforge.components.stock.swagger;
+
+import java.util.UUID;
+
+public record StockGetByDeviceRequestDTO(
+        UUID deviceUuid
+) {}

--- a/src/main/java/de/pschiessle/lumenforge/components/stock/swagger/StockGetByDeviceResponseDTO.java
+++ b/src/main/java/de/pschiessle/lumenforge/components/stock/swagger/StockGetByDeviceResponseDTO.java
@@ -1,0 +1,7 @@
+package de.pschiessle.lumenforge.components.stock.swagger;
+
+import de.pschiessle.lumenforge.components.stock.response.StockResponseDTO;
+
+public record StockGetByDeviceResponseDTO(
+        StockResponseDTO stock
+) {}

--- a/src/main/java/de/pschiessle/lumenforge/components/stock/swagger/StockPatchCountRequestDTO.java
+++ b/src/main/java/de/pschiessle/lumenforge/components/stock/swagger/StockPatchCountRequestDTO.java
@@ -1,0 +1,9 @@
+package de.pschiessle.lumenforge.components.stock.swagger;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+public record StockPatchCountRequestDTO(
+        UUID deviceUuid,
+        BigDecimal stockCount
+) {}

--- a/src/main/java/de/pschiessle/lumenforge/components/stock/swagger/StockPatchCountResponseDTO.java
+++ b/src/main/java/de/pschiessle/lumenforge/components/stock/swagger/StockPatchCountResponseDTO.java
@@ -1,0 +1,7 @@
+package de.pschiessle.lumenforge.components.stock.swagger;
+
+import de.pschiessle.lumenforge.components.stock.response.StockResponseDTO;
+
+public record StockPatchCountResponseDTO(
+        StockResponseDTO stock
+) {}

--- a/src/main/java/de/pschiessle/lumenforge/components/stock/swagger/StockUpsertByDeviceRequestDTO.java
+++ b/src/main/java/de/pschiessle/lumenforge/components/stock/swagger/StockUpsertByDeviceRequestDTO.java
@@ -1,0 +1,10 @@
+package de.pschiessle.lumenforge.components.stock.swagger;
+
+import de.pschiessle.lumenforge.components.stock.request.StockRequestDTO;
+
+import java.util.UUID;
+
+public record StockUpsertByDeviceRequestDTO(
+        UUID deviceUuid,
+        StockRequestDTO stock
+) {}

--- a/src/main/java/de/pschiessle/lumenforge/components/stock/swagger/StockUpsertByDeviceResponseDTO.java
+++ b/src/main/java/de/pschiessle/lumenforge/components/stock/swagger/StockUpsertByDeviceResponseDTO.java
@@ -1,0 +1,7 @@
+package de.pschiessle.lumenforge.components.stock.swagger;
+
+import de.pschiessle.lumenforge.components.stock.response.StockResponseDTO;
+
+public record StockUpsertByDeviceResponseDTO(
+        StockResponseDTO stock
+) {}

--- a/src/main/java/de/pschiessle/lumenforge/components/vendor/swagger/VendorGetAllRequestDTO.java
+++ b/src/main/java/de/pschiessle/lumenforge/components/vendor/swagger/VendorGetAllRequestDTO.java
@@ -1,0 +1,7 @@
+package de.pschiessle.lumenforge.components.vendor.swagger;
+
+public record VendorGetAllRequestDTO(
+        Integer page,
+        Integer size,
+        String sort
+) {}

--- a/src/main/java/de/pschiessle/lumenforge/components/vendor/swagger/VendorGetAllResponseDTO.java
+++ b/src/main/java/de/pschiessle/lumenforge/components/vendor/swagger/VendorGetAllResponseDTO.java
@@ -1,0 +1,11 @@
+package de.pschiessle.lumenforge.components.vendor.swagger;
+
+import java.util.List;
+
+public record VendorGetAllResponseDTO(
+        List<VendorResponseDTO> content,
+        Integer pageNumber,
+        Integer pageSize,
+        Long totalElements,
+        Integer totalPages
+) {}

--- a/src/main/java/de/pschiessle/lumenforge/components/vendor/swagger/VendorResponseDTO.java
+++ b/src/main/java/de/pschiessle/lumenforge/components/vendor/swagger/VendorResponseDTO.java
@@ -1,0 +1,7 @@
+package de.pschiessle.lumenforge.components.vendor.swagger;
+
+public record VendorResponseDTO(
+        Long id,
+        String uuid,
+        String name
+) {}

--- a/src/main/java/de/pschiessle/lumenforge/components/vendor/swagger/VendorSearchRequestDTO.java
+++ b/src/main/java/de/pschiessle/lumenforge/components/vendor/swagger/VendorSearchRequestDTO.java
@@ -1,0 +1,8 @@
+package de.pschiessle.lumenforge.components.vendor.swagger;
+
+public record VendorSearchRequestDTO(
+        String query,
+        Integer page,
+        Integer size,
+        String sort
+) {}

--- a/src/main/java/de/pschiessle/lumenforge/components/vendor/swagger/VendorSearchResponseDTO.java
+++ b/src/main/java/de/pschiessle/lumenforge/components/vendor/swagger/VendorSearchResponseDTO.java
@@ -1,0 +1,11 @@
+package de.pschiessle.lumenforge.components.vendor.swagger;
+
+import java.util.List;
+
+public record VendorSearchResponseDTO(
+        List<VendorResponseDTO> content,
+        Integer pageNumber,
+        Integer pageSize,
+        Long totalElements,
+        Integer totalPages
+) {}

--- a/src/main/resources/swagger/category.yaml
+++ b/src/main/resources/swagger/category.yaml
@@ -1,0 +1,140 @@
+openapi: 3.0.3
+info:
+  title: Category API
+  version: 1.0.0
+paths:
+  /api/categories:
+    get:
+      summary: List categories
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CategoryGetAllRequestDTO'
+      parameters:
+        - name: page
+          in: query
+          required: false
+          schema:
+            type: integer
+        - name: size
+          in: query
+          required: false
+          schema:
+            type: integer
+        - name: sort
+          in: query
+          required: false
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Category page
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CategoryGetAllResponseDTO'
+  /api/categories/search:
+    get:
+      summary: Search categories
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CategorySearchRequestDTO'
+      parameters:
+        - name: query
+          in: query
+          required: true
+          schema:
+            type: string
+        - name: page
+          in: query
+          required: false
+          schema:
+            type: integer
+        - name: size
+          in: query
+          required: false
+          schema:
+            type: integer
+        - name: sort
+          in: query
+          required: false
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Category search results
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CategorySearchResponseDTO'
+components:
+  schemas:
+    CategoryGetAllRequestDTO:
+      type: object
+      properties:
+        page:
+          type: integer
+        size:
+          type: integer
+        sort:
+          type: string
+    CategoryGetAllResponseDTO:
+      type: object
+      properties:
+        content:
+          type: array
+          items:
+            $ref: '#/components/schemas/CategoryResponseDTO'
+        pageNumber:
+          type: integer
+        pageSize:
+          type: integer
+        totalElements:
+          type: integer
+          format: int64
+        totalPages:
+          type: integer
+    CategorySearchRequestDTO:
+      type: object
+      properties:
+        query:
+          type: string
+        page:
+          type: integer
+        size:
+          type: integer
+        sort:
+          type: string
+    CategorySearchResponseDTO:
+      type: object
+      properties:
+        content:
+          type: array
+          items:
+            $ref: '#/components/schemas/CategoryResponseDTO'
+        pageNumber:
+          type: integer
+        pageSize:
+          type: integer
+        totalElements:
+          type: integer
+          format: int64
+        totalPages:
+          type: integer
+    CategoryResponseDTO:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        uuid:
+          type: string
+        name:
+          type: string
+        description:
+          type: string

--- a/src/main/resources/swagger/device.yaml
+++ b/src/main/resources/swagger/device.yaml
@@ -1,0 +1,409 @@
+openapi: 3.0.3
+info:
+  title: Device API
+  version: 1.0.0
+paths:
+  /api/v1/user/devices/{id}:
+    get:
+      summary: Get a device by ID
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DeviceGetByIdRequestDTO'
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '200':
+          description: Device found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DeviceGetByIdResponseDTO'
+    put:
+      summary: Update a device by ID
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DeviceUpdateRequestDTO'
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '200':
+          description: Device updated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DeviceUpdateResponseDTO'
+    delete:
+      summary: Delete a device by ID
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DeviceDeleteRequestDTO'
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '200':
+          description: Device deleted
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DeviceDeleteResponseDTO'
+  /api/v1/user/devices:
+    get:
+      summary: List devices
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DeviceGetPageBasicRequestDTO'
+      parameters:
+        - name: q
+          in: query
+          required: false
+          schema:
+            type: string
+        - name: page
+          in: query
+          required: false
+          schema:
+            type: integer
+        - name: size
+          in: query
+          required: false
+          schema:
+            type: integer
+        - name: sort
+          in: query
+          required: false
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Device page
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DeviceGetPageBasicResponseDTO'
+    post:
+      summary: Create a device
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DeviceCreateRequestDTO'
+      responses:
+        '201':
+          description: Device created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DeviceCreateResponseDTO'
+  /api/v1/user/devices/with-stock:
+    get:
+      summary: List devices with stock
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DeviceGetPageWithStockRequestDTO'
+      parameters:
+        - name: q
+          in: query
+          required: false
+          schema:
+            type: string
+        - name: page
+          in: query
+          required: false
+          schema:
+            type: integer
+        - name: size
+          in: query
+          required: false
+          schema:
+            type: integer
+        - name: sort
+          in: query
+          required: false
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Device page with stock
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DeviceGetPageWithStockResponseDTO'
+  /api/v1/user/devices/by-uuid/{uuid}:
+    get:
+      summary: Get a device by UUID
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DeviceGetByUuidRequestDTO'
+      parameters:
+        - name: uuid
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          description: Device found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DeviceGetByUuidResponseDTO'
+components:
+  schemas:
+    DeviceGetByIdRequestDTO:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+    DeviceGetByIdResponseDTO:
+      type: object
+      properties:
+        device:
+          $ref: '#/components/schemas/DeviceResponseDTO'
+    DeviceGetPageBasicRequestDTO:
+      type: object
+      properties:
+        q:
+          type: string
+        page:
+          type: integer
+        size:
+          type: integer
+        sort:
+          type: string
+    DeviceGetPageBasicResponseDTO:
+      type: object
+      properties:
+        content:
+          type: array
+          items:
+            $ref: '#/components/schemas/DeviceListDTO'
+        pageNumber:
+          type: integer
+        pageSize:
+          type: integer
+        totalElements:
+          type: integer
+          format: int64
+        totalPages:
+          type: integer
+    DeviceGetPageWithStockRequestDTO:
+      type: object
+      properties:
+        q:
+          type: string
+        page:
+          type: integer
+        size:
+          type: integer
+        sort:
+          type: string
+    DeviceGetPageWithStockResponseDTO:
+      type: object
+      properties:
+        content:
+          type: array
+          items:
+            $ref: '#/components/schemas/DeviceListWithStockDTO'
+        pageNumber:
+          type: integer
+        pageSize:
+          type: integer
+        totalElements:
+          type: integer
+          format: int64
+        totalPages:
+          type: integer
+    DeviceGetByUuidRequestDTO:
+      type: object
+      properties:
+        uuid:
+          type: string
+          format: uuid
+    DeviceGetByUuidResponseDTO:
+      type: object
+      properties:
+        device:
+          $ref: '#/components/schemas/DeviceResponseDTO'
+    DeviceCreateRequestDTO:
+      type: object
+      properties:
+        device:
+          $ref: '#/components/schemas/DeviceRequestDTO'
+    DeviceCreateResponseDTO:
+      type: object
+      properties:
+        device:
+          $ref: '#/components/schemas/DeviceResponseDTO'
+    DeviceUpdateRequestDTO:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        device:
+          $ref: '#/components/schemas/DeviceRequestDTO'
+    DeviceUpdateResponseDTO:
+      type: object
+      properties:
+        device:
+          $ref: '#/components/schemas/DeviceResponseDTO'
+    DeviceDeleteRequestDTO:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+    DeviceDeleteResponseDTO:
+      type: object
+      properties:
+        message:
+          type: string
+    DeviceRequestDTO:
+      type: object
+      properties:
+        serialNumber:
+          type: string
+        name:
+          type: string
+        description:
+          type: string
+        photoUrl:
+          type: string
+        vendorId:
+          type: integer
+          format: int64
+        purchasePrice:
+          type: number
+          format: double
+        purchaseDate:
+          type: string
+          format: date
+        categoryIds:
+          type: array
+          items:
+            type: integer
+            format: int64
+        maintenanceStatusId:
+          type: integer
+          format: int64
+        stockRequestDTO:
+          $ref: '#/components/schemas/StockRequestDTO'
+    DeviceResponseDTO:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        uuid:
+          type: string
+          format: uuid
+        serialNumber:
+          type: string
+        name:
+          type: string
+        description:
+          type: string
+        photoUrl:
+          type: string
+        vendorId:
+          type: integer
+          format: int64
+        purchasePrice:
+          type: number
+          format: double
+        purchaseDate:
+          type: string
+          format: date
+        categoryIds:
+          type: array
+          items:
+            type: integer
+            format: int64
+        maintenanceStatusId:
+          type: integer
+          format: int64
+        createDate:
+          type: string
+          format: date-time
+        updateDate:
+          type: string
+          format: date-time
+    DeviceListDTO:
+      type: object
+      properties:
+        uuid:
+          type: string
+          format: uuid
+        name:
+          type: string
+        serialNumber:
+          type: string
+    DeviceListWithStockDTO:
+      type: object
+      properties:
+        uuid:
+          type: string
+          format: uuid
+        name:
+          type: string
+        serialNumber:
+          type: string
+        stockCount:
+          type: number
+          format: double
+        stockUnitType:
+          $ref: '#/components/schemas/StockUnitType'
+        vendorName:
+          type: string
+    StockRequestDTO:
+      type: object
+      properties:
+        stockUnitType:
+          $ref: '#/components/schemas/StockUnitType'
+        stockCount:
+          type: number
+          format: double
+        isFractional:
+          type: boolean
+    StockUnitType:
+      type: string
+      enum:
+        - GRAM
+        - MILLILITER
+        - PIECES

--- a/src/main/resources/swagger/maintenance-status.yaml
+++ b/src/main/resources/swagger/maintenance-status.yaml
@@ -1,0 +1,140 @@
+openapi: 3.0.3
+info:
+  title: Maintenance Status API
+  version: 1.0.0
+paths:
+  /api/maintenance-statuses:
+    get:
+      summary: List maintenance statuses
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/MaintenanceStatusGetAllRequestDTO'
+      parameters:
+        - name: page
+          in: query
+          required: false
+          schema:
+            type: integer
+        - name: size
+          in: query
+          required: false
+          schema:
+            type: integer
+        - name: sort
+          in: query
+          required: false
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Maintenance status page
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MaintenanceStatusGetAllResponseDTO'
+  /api/maintenance-statuses/search:
+    get:
+      summary: Search maintenance statuses
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/MaintenanceStatusSearchRequestDTO'
+      parameters:
+        - name: query
+          in: query
+          required: true
+          schema:
+            type: string
+        - name: page
+          in: query
+          required: false
+          schema:
+            type: integer
+        - name: size
+          in: query
+          required: false
+          schema:
+            type: integer
+        - name: sort
+          in: query
+          required: false
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Maintenance status search results
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MaintenanceStatusSearchResponseDTO'
+components:
+  schemas:
+    MaintenanceStatusGetAllRequestDTO:
+      type: object
+      properties:
+        page:
+          type: integer
+        size:
+          type: integer
+        sort:
+          type: string
+    MaintenanceStatusGetAllResponseDTO:
+      type: object
+      properties:
+        content:
+          type: array
+          items:
+            $ref: '#/components/schemas/MaintenanceStatusResponseDTO'
+        pageNumber:
+          type: integer
+        pageSize:
+          type: integer
+        totalElements:
+          type: integer
+          format: int64
+        totalPages:
+          type: integer
+    MaintenanceStatusSearchRequestDTO:
+      type: object
+      properties:
+        query:
+          type: string
+        page:
+          type: integer
+        size:
+          type: integer
+        sort:
+          type: string
+    MaintenanceStatusSearchResponseDTO:
+      type: object
+      properties:
+        content:
+          type: array
+          items:
+            $ref: '#/components/schemas/MaintenanceStatusResponseDTO'
+        pageNumber:
+          type: integer
+        pageSize:
+          type: integer
+        totalElements:
+          type: integer
+          format: int64
+        totalPages:
+          type: integer
+    MaintenanceStatusResponseDTO:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        uuid:
+          type: string
+        name:
+          type: string
+        description:
+          type: string

--- a/src/main/resources/swagger/stock.yaml
+++ b/src/main/resources/swagger/stock.yaml
@@ -1,0 +1,178 @@
+openapi: 3.0.3
+info:
+  title: Stock API
+  version: 1.0.0
+paths:
+  /api/stocks/device/{deviceUuid}:
+    get:
+      summary: Get stock by device UUID
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/StockGetByDeviceRequestDTO'
+      parameters:
+        - name: deviceUuid
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          description: Stock found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StockGetByDeviceResponseDTO'
+    put:
+      summary: Upsert stock by device UUID
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/StockUpsertByDeviceRequestDTO'
+      parameters:
+        - name: deviceUuid
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          description: Stock updated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StockUpsertByDeviceResponseDTO'
+    delete:
+      summary: Delete stock by device UUID
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/StockDeleteByDeviceRequestDTO'
+      parameters:
+        - name: deviceUuid
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          description: Stock deleted
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StockDeleteByDeviceResponseDTO'
+  /api/stocks/device/{deviceUuid}/count:
+    patch:
+      summary: Patch stock count by device UUID
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/StockPatchCountRequestDTO'
+      parameters:
+        - name: deviceUuid
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          description: Stock count updated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StockPatchCountResponseDTO'
+components:
+  schemas:
+    StockGetByDeviceRequestDTO:
+      type: object
+      properties:
+        deviceUuid:
+          type: string
+          format: uuid
+    StockGetByDeviceResponseDTO:
+      type: object
+      properties:
+        stock:
+          $ref: '#/components/schemas/StockResponseDTO'
+    StockUpsertByDeviceRequestDTO:
+      type: object
+      properties:
+        deviceUuid:
+          type: string
+          format: uuid
+        stock:
+          $ref: '#/components/schemas/StockRequestDTO'
+    StockUpsertByDeviceResponseDTO:
+      type: object
+      properties:
+        stock:
+          $ref: '#/components/schemas/StockResponseDTO'
+    StockPatchCountRequestDTO:
+      type: object
+      properties:
+        deviceUuid:
+          type: string
+          format: uuid
+        stockCount:
+          type: number
+          format: double
+    StockPatchCountResponseDTO:
+      type: object
+      properties:
+        stock:
+          $ref: '#/components/schemas/StockResponseDTO'
+    StockDeleteByDeviceRequestDTO:
+      type: object
+      properties:
+        deviceUuid:
+          type: string
+          format: uuid
+    StockDeleteByDeviceResponseDTO:
+      type: object
+      properties:
+        message:
+          type: string
+    StockRequestDTO:
+      type: object
+      properties:
+        stockUnitType:
+          $ref: '#/components/schemas/StockUnitType'
+        stockCount:
+          type: number
+          format: double
+        isFractional:
+          type: boolean
+    StockResponseDTO:
+      type: object
+      properties:
+        deviceUuid:
+          type: string
+          format: uuid
+        stockUuid:
+          type: string
+          format: uuid
+        stockUnitType:
+          $ref: '#/components/schemas/StockUnitType'
+        stockCount:
+          type: number
+          format: double
+        isFractional:
+          type: boolean
+    StockUnitType:
+      type: string
+      enum:
+        - GRAM
+        - MILLILITER
+        - PIECES

--- a/src/main/resources/swagger/vendor.yaml
+++ b/src/main/resources/swagger/vendor.yaml
@@ -1,0 +1,138 @@
+openapi: 3.0.3
+info:
+  title: Vendor API
+  version: 1.0.0
+paths:
+  /api/vendors:
+    get:
+      summary: List vendors
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/VendorGetAllRequestDTO'
+      parameters:
+        - name: page
+          in: query
+          required: false
+          schema:
+            type: integer
+        - name: size
+          in: query
+          required: false
+          schema:
+            type: integer
+        - name: sort
+          in: query
+          required: false
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Vendor page
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/VendorGetAllResponseDTO'
+  /api/vendors/search:
+    get:
+      summary: Search vendors
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/VendorSearchRequestDTO'
+      parameters:
+        - name: query
+          in: query
+          required: true
+          schema:
+            type: string
+        - name: page
+          in: query
+          required: false
+          schema:
+            type: integer
+        - name: size
+          in: query
+          required: false
+          schema:
+            type: integer
+        - name: sort
+          in: query
+          required: false
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Vendor search results
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/VendorSearchResponseDTO'
+components:
+  schemas:
+    VendorGetAllRequestDTO:
+      type: object
+      properties:
+        page:
+          type: integer
+        size:
+          type: integer
+        sort:
+          type: string
+    VendorGetAllResponseDTO:
+      type: object
+      properties:
+        content:
+          type: array
+          items:
+            $ref: '#/components/schemas/VendorResponseDTO'
+        pageNumber:
+          type: integer
+        pageSize:
+          type: integer
+        totalElements:
+          type: integer
+          format: int64
+        totalPages:
+          type: integer
+    VendorSearchRequestDTO:
+      type: object
+      properties:
+        query:
+          type: string
+        page:
+          type: integer
+        size:
+          type: integer
+        sort:
+          type: string
+    VendorSearchResponseDTO:
+      type: object
+      properties:
+        content:
+          type: array
+          items:
+            $ref: '#/components/schemas/VendorResponseDTO'
+        pageNumber:
+          type: integer
+        pageSize:
+          type: integer
+        totalElements:
+          type: integer
+          format: int64
+        totalPages:
+          type: integer
+    VendorResponseDTO:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        uuid:
+          type: string
+        name:
+          type: string


### PR DESCRIPTION
### Motivation

- Provide OpenAPI/Swagger documentation for each controller (device, category, maintenanceStatus, stock, vendor) so APIs are discoverable and spec-compliant. 
- Add explicit request/response DTO types for every endpoint to make the Swagger schemas concrete and to standardize payloads used in documentation. 

### Description

- Added per-controller OpenAPI YAML files under `src/main/resources/swagger/` for `device.yaml`, `category.yaml`, `maintenance-status.yaml`, `stock.yaml`, and `vendor.yaml` describing paths and component schemas. 
- Introduced Java `record` DTO types under `src/main/java/de/pschiessle/lumenforge/components/*/swagger/` for each endpoint (request and response DTOs) including device, stock, category, maintenance status and vendor records that map to the OpenAPI schemas. 
- Reused existing domain/DTO types where appropriate (for example `DeviceRequestDTO`, `DeviceResponseDTO`, `StockRequestDTO`, and `StockResponseDTO`) inside the new wrapper swagger records to keep parity with controller inputs/outputs. 
- In total the change adds the per-endpoint DTO records and five Swagger YAML specs (commit recorded ~42 files added). 

### Testing

- No automated tests were run against the changes. 
- Files were created and committed (`git commit` completed) but no build or test command such as `./gradlew build` or unit tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697f975edaa083268e49372740d44598)